### PR TITLE
Improvements and use of legacy image fields

### DIFF
--- a/src/drupal/composer.json
+++ b/src/drupal/composer.json
@@ -171,9 +171,6 @@
             },
             "geocoder-php/mapbox-provider": {
                 "Force adding locality/bezirk string to output": "patches/mapbox-provider-locality.patch"
-            },
-            "drupal/gin": {
-                "Fixes live preview button not working in edit forms": "patches/3220780-gin-event-bindings.patch"
             }
         }
     }

--- a/src/drupal/composer.json
+++ b/src/drupal/composer.json
@@ -171,6 +171,10 @@
             },
             "geocoder-php/mapbox-provider": {
                 "Force adding locality/bezirk string to output": "patches/mapbox-provider-locality.patch"
+            },
+            "drupal/gin": {
+                "moves actions back into sidebar": "patches/gin_editform_actions.patch",
+                "prevents deletion of actions after preview closes": "patches/gin_editform_theme_actions.patch"
             }
         }
     }

--- a/src/drupal/config/sync/core.entity_form_display.node.blog_article.default.yml
+++ b/src/drupal/config/sync/core.entity_form_display.node.blog_article.default.yml
@@ -5,15 +5,18 @@ dependencies:
   config:
     - field.field.node.blog_article.body
     - field.field.node.blog_article.field_images
+    - field.field.node.blog_article.field_images_legacy
     - field.field.node.blog_article.field_is_featured
     - field.field.node.blog_article.field_main_image
+    - field.field.node.blog_article.field_main_image_legacy
     - field.field.node.blog_article.field_related_content
     - field.field.node.blog_article.og_audience
+    - image.style.thumbnail
     - node.type.blog_article
   module:
     - field_group
-    - media_library
     - publication_date
+    - svg_image
     - text
 third_party_settings:
   field_group:
@@ -66,8 +69,8 @@ third_party_settings:
       label: Allgemein
     group_images:
       children:
-        - field_main_image
-        - field_images
+        - field_main_image_legacy
+        - field_images_legacy
       parent_name: group_basic
       weight: 21
       format_type: accordion_item
@@ -114,12 +117,13 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
-  field_images:
-    type: media_library_widget
-    weight: 23
+  field_images_legacy:
+    weight: 24
     settings:
-      media_types: {  }
+      progress_indicator: throbber
+      preview_image_style: thumbnail
     third_party_settings: {  }
+    type: image_image
     region: content
   field_is_featured:
     weight: 23
@@ -128,12 +132,13 @@ content:
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
-  field_main_image:
-    weight: 22
+  field_main_image_legacy:
+    weight: 23
     settings:
-      media_types: {  }
+      progress_indicator: throbber
+      preview_image_style: thumbnail
     third_party_settings: {  }
-    type: media_library_widget
+    type: image_image
     region: content
   field_related_content:
     weight: 24
@@ -190,6 +195,8 @@ content:
     region: content
     third_party_settings: {  }
 hidden:
+  field_images: true
+  field_main_image: true
   path: true
   promote: true
   sticky: true

--- a/src/drupal/config/sync/core.entity_form_display.node.partner.default.yml
+++ b/src/drupal/config/sync/core.entity_form_display.node.partner.default.yml
@@ -6,15 +6,17 @@ dependencies:
     - field.field.node.partner.field_akteur
     - field.field.node.partner.field_description
     - field.field.node.partner.field_main_image
+    - field.field.node.partner.field_main_image_legacy
     - field.field.node.partner.field_partner_type
     - field.field.node.partner.field_website
     - field.field.node.partner.og_audience
+    - image.style.thumbnail
     - node.type.partner
   module:
     - conditional_fields
     - field_group
-    - media_library
     - select2
+    - svg_image
     - text
 third_party_settings:
   field_group:
@@ -92,30 +94,13 @@ content:
           bundle: partner
     type: text_textarea
     region: content
-  field_main_image:
+  field_main_image_legacy:
     weight: 7
     settings:
-      media_types: {  }
-    third_party_settings:
-      conditional_fields:
-        cbe03f27-418b-402f-9dae-8086a7b51434:
-          dependee: field_partner_type
-          settings:
-            state: visible
-            condition: value
-            grouping: AND
-            values_set: 1
-            value: ''
-            values: {  }
-            value_form:
-              -
-                value: custom
-            effect: show
-            effect_options: {  }
-            selector: ''
-          entity_type: node
-          bundle: partner
-    type: media_library_widget
+      progress_indicator: throbber
+      preview_image_style: thumbnail
+    third_party_settings: {  }
+    type: image_image
     region: content
   field_partner_type:
     weight: 2
@@ -197,6 +182,7 @@ content:
           bundle: partner
 hidden:
   created: true
+  field_main_image: true
   path: true
   promote: true
   published_at: true

--- a/src/drupal/config/sync/core.entity_form_display.node.project.default.yml
+++ b/src/drupal/config/sync/core.entity_form_display.node.project.default.yml
@@ -5,15 +5,18 @@ dependencies:
   config:
     - field.field.node.project.body
     - field.field.node.project.field_images
+    - field.field.node.project.field_images_legacy
     - field.field.node.project.field_is_featured
     - field.field.node.project.field_legal_terms_accepted
     - field.field.node.project.field_main_image
+    - field.field.node.project.field_main_image_legacy
     - field.field.node.project.field_related_content
     - field.field.node.project.og_audience
+    - image.style.thumbnail
     - node.type.project
   module:
     - field_group
-    - media_library
+    - svg_image
     - text
 third_party_settings:
   field_group:
@@ -62,8 +65,8 @@ third_party_settings:
       label: Allgemein
     group_images:
       children:
-        - field_main_image
-        - field_images
+        - field_main_image_legacy
+        - field_images_legacy
       parent_name: group_basic
       weight: 21
       format_type: accordion_item
@@ -104,12 +107,13 @@ content:
       show_summary: false
     third_party_settings: {  }
     region: content
-  field_images:
-    weight: 6
+  field_images_legacy:
+    weight: 8
     settings:
-      media_types: {  }
+      progress_indicator: throbber
+      preview_image_style: thumbnail
     third_party_settings: {  }
-    type: media_library_widget
+    type: image_image
     region: content
   field_is_featured:
     weight: 3
@@ -125,12 +129,13 @@ content:
     third_party_settings: {  }
     type: boolean_checkbox
     region: content
-  field_main_image:
-    type: media_library_widget
-    weight: 5
+  field_main_image_legacy:
+    weight: 6
     settings:
-      media_types: {  }
+      progress_indicator: throbber
+      preview_image_style: thumbnail
     third_party_settings: {  }
+    type: image_image
     region: content
   field_related_content:
     weight: 5
@@ -172,6 +177,8 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_images: true
+  field_main_image: true
   path: true
   promote: true
   published_at: true

--- a/src/drupal/config/sync/core.entity_form_display.node.sponsor.default.yml
+++ b/src/drupal/config/sync/core.entity_form_display.node.sponsor.default.yml
@@ -4,12 +4,14 @@ status: true
 dependencies:
   config:
     - field.field.node.sponsor.field_logo
+    - field.field.node.sponsor.field_logo_legacy
     - field.field.node.sponsor.field_website
     - field.field.node.sponsor.og_audience
+    - image.style.thumbnail
     - node.type.sponsor
   module:
     - field_group
-    - media_library
+    - svg_image
 third_party_settings:
   field_group:
     group_settings:
@@ -32,12 +34,13 @@ targetEntityType: node
 bundle: sponsor
 mode: default
 content:
-  field_logo:
+  field_logo_legacy:
     weight: 4
     settings:
-      media_types: {  }
+      progress_indicator: throbber
+      preview_image_style: thumbnail
     third_party_settings: {  }
-    type: media_library_widget
+    type: image_image
     region: content
   field_website:
     weight: 3
@@ -77,6 +80,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_logo: true
   path: true
   promote: true
   published_at: true

--- a/src/drupal/config/sync/core.entity_form_display.node.webbuilder.default.yml
+++ b/src/drupal/config/sync/core.entity_form_display.node.webbuilder.default.yml
@@ -26,7 +26,6 @@ dependencies:
     - media_library
     - path
     - publication_date
-    - select2
     - text
 third_party_settings:
   field_group:
@@ -133,10 +132,9 @@ content:
     region: content
   field_fonts:
     weight: 12
-    settings:
-      width: 100%
+    settings: {  }
     third_party_settings: {  }
-    type: select2
+    type: options_buttons
     region: content
   field_instagram_link:
     weight: 12

--- a/src/drupal/config/sync/core.entity_form_display.node.webbuilder.default.yml
+++ b/src/drupal/config/sync/core.entity_form_display.node.webbuilder.default.yml
@@ -14,10 +14,12 @@ dependencies:
     - field.field.node.webbuilder.field_is_preset
     - field.field.node.webbuilder.field_layout
     - field.field.node.webbuilder.field_logo
+    - field.field.node.webbuilder.field_logo_legacy
     - field.field.node.webbuilder.field_preview_image
     - field.field.node.webbuilder.field_projects_page
     - field.field.node.webbuilder.field_twitter_link
     - field.field.node.webbuilder.og_audience
+    - image.style.thumbnail
     - node.type.webbuilder
   module:
     - color_field
@@ -26,6 +28,7 @@ dependencies:
     - media_library
     - path
     - publication_date
+    - svg_image
     - text
 third_party_settings:
   field_group:
@@ -48,7 +51,7 @@ third_party_settings:
         - field_layout
         - field_color_primary
         - field_fonts
-        - field_logo
+        - field_logo_legacy
       parent_name: group_basic
       weight: 9
       format_type: accordion_item
@@ -157,12 +160,13 @@ content:
     third_party_settings: {  }
     type: options_select
     region: content
-  field_logo:
-    type: media_library_widget
-    weight: 13
+  field_logo_legacy:
+    weight: 14
     settings:
-      media_types: {  }
+      progress_indicator: throbber
+      preview_image_style: thumbnail
     third_party_settings: {  }
+    type: image_image
     region: content
   field_preview_image:
     weight: 9
@@ -217,6 +221,7 @@ hidden:
   field_blog_page: true
   field_events_page: true
   field_frontpage: true
+  field_logo: true
   field_projects_page: true
   langcode: true
   promote: true

--- a/src/drupal/config/sync/core.entity_form_display.node.webbuilder_page.default.yml
+++ b/src/drupal/config/sync/core.entity_form_display.node.webbuilder_page.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.webbuilder_page.field_contents
     - field.field.node.webbuilder_page.field_header_image
+    - field.field.node.webbuilder_page.field_header_image_legacy
     - field.field.node.webbuilder_page.field_navigation
     - field.field.node.webbuilder_page.field_parent
     - field.field.node.webbuilder_page.field_pre_footer_body
@@ -15,14 +16,15 @@ dependencies:
     - field.field.node.webbuilder_page.field_webbuilder
     - field.field.node.webbuilder_page.field_weight
     - field.field.node.webbuilder_page.og_audience
+    - image.style.thumbnail
     - node.type.webbuilder_page
   module:
     - field_group
     - link
-    - media_library
     - paragraphs
     - publication_date
     - select2
+    - svg_image
     - text
     - weight
 third_party_settings:
@@ -76,7 +78,7 @@ third_party_settings:
       label: Navigation
     group_header:
       children:
-        - field_header_image
+        - field_header_image_legacy
       parent_name: group_basic
       weight: 18
       format_type: accordion_item
@@ -156,12 +158,13 @@ content:
         duplicate: duplicate
     third_party_settings: {  }
     region: content
-  field_header_image:
-    type: media_library_widget
-    weight: 3
+  field_header_image_legacy:
+    weight: 4
     settings:
-      media_types: {  }
+      progress_indicator: throbber
+      preview_image_style: thumbnail
     third_party_settings: {  }
+    type: image_image
     region: content
   field_navigation:
     weight: 3
@@ -271,6 +274,7 @@ content:
     third_party_settings: {  }
 hidden:
   created: true
+  field_header_image: true
   path: true
   promote: true
   sticky: true

--- a/src/drupal/config/sync/core.entity_form_display.user.user.default.yml
+++ b/src/drupal/config/sync/core.entity_form_display.user.user.default.yml
@@ -19,6 +19,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  matomo:
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   path:
     type: path
     weight: 2

--- a/src/drupal/config/sync/core.entity_form_display.user.user.register.yml
+++ b/src/drupal/config/sync/core.entity_form_display.user.user.register.yml
@@ -24,6 +24,11 @@ content:
     region: content
     settings: {  }
     third_party_settings: {  }
+  matomo:
+    weight: 3
+    settings: {  }
+    third_party_settings: {  }
+    region: content
   timezone:
     weight: 2
     region: content

--- a/src/drupal/config/sync/core.entity_view_display.node.blog_article.backend_teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.blog_article.backend_teaser.yml
@@ -6,14 +6,16 @@ dependencies:
     - core.entity_view_mode.node.backend_teaser
     - field.field.node.blog_article.body
     - field.field.node.blog_article.field_images
+    - field.field.node.blog_article.field_images_legacy
     - field.field.node.blog_article.field_is_featured
     - field.field.node.blog_article.field_main_image
+    - field.field.node.blog_article.field_main_image_legacy
     - field.field.node.blog_article.field_related_content
     - field.field.node.blog_article.og_audience
     - image.style.medium
     - node.type.blog_article
   module:
-    - media
+    - svg_image
     - text
     - user
 id: node.blog_article.backend_teaser
@@ -39,15 +41,19 @@ content:
       format_custom_true: ''
       format_custom_false: ''
     third_party_settings: {  }
-  field_main_image:
+  field_main_image_legacy:
+    type: image
     weight: 0
+    region: content
     label: hidden
     settings:
       image_style: medium
       image_link: ''
+      svg_render_as_image: true
+      svg_attributes:
+        width: null
+        height: null
     third_party_settings: {  }
-    type: media_thumbnail
-    region: content
   published_at:
     type: timestamp
     weight: 1
@@ -60,6 +66,8 @@ content:
     third_party_settings: {  }
 hidden:
   field_images: true
+  field_images_legacy: true
+  field_main_image: true
   field_related_content: true
   langcode: true
   links: true

--- a/src/drupal/config/sync/core.entity_view_display.node.blog_article.default.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.blog_article.default.yml
@@ -5,12 +5,15 @@ dependencies:
   config:
     - field.field.node.blog_article.body
     - field.field.node.blog_article.field_images
+    - field.field.node.blog_article.field_images_legacy
     - field.field.node.blog_article.field_is_featured
     - field.field.node.blog_article.field_main_image
+    - field.field.node.blog_article.field_main_image_legacy
     - field.field.node.blog_article.field_related_content
     - field.field.node.blog_article.og_audience
     - node.type.blog_article
   module:
+    - svg_image
     - text
     - user
 id: node.blog_article.default
@@ -25,14 +28,18 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-  field_images:
-    type: entity_reference_entity_view
+  field_images_legacy:
     weight: 5
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
+    type: image
     region: content
   field_is_featured:
     weight: 6
@@ -44,14 +51,18 @@ content:
     third_party_settings: {  }
     type: boolean
     region: content
-  field_main_image:
+  field_main_image_legacy:
     weight: 3
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
-    type: entity_reference_entity_view
+    type: image
     region: content
   field_related_content:
     weight: 7
@@ -86,4 +97,6 @@ content:
       timezone: ''
     third_party_settings: {  }
 hidden:
+  field_images: true
+  field_main_image: true
   langcode: true

--- a/src/drupal/config/sync/core.entity_view_display.node.blog_article.in_webbuilder.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.blog_article.in_webbuilder.yml
@@ -6,12 +6,15 @@ dependencies:
     - core.entity_view_mode.node.in_webbuilder
     - field.field.node.blog_article.body
     - field.field.node.blog_article.field_images
+    - field.field.node.blog_article.field_images_legacy
     - field.field.node.blog_article.field_is_featured
     - field.field.node.blog_article.field_main_image
+    - field.field.node.blog_article.field_main_image_legacy
     - field.field.node.blog_article.field_related_content
     - field.field.node.blog_article.og_audience
     - node.type.blog_article
   module:
+    - svg_image
     - text
     - user
 id: node.blog_article.in_webbuilder
@@ -45,15 +48,19 @@ content:
       format_custom_true: ''
       format_custom_false: ''
     third_party_settings: {  }
-  field_main_image:
+  field_main_image_legacy:
+    type: image
     weight: 4
+    region: content
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
-    type: entity_reference_entity_view
-    region: content
   field_related_content:
     type: entity_reference_entity_view
     weight: 7
@@ -87,4 +94,6 @@ content:
       timezone: ''
     third_party_settings: {  }
 hidden:
+  field_images_legacy: true
+  field_main_image: true
   langcode: true

--- a/src/drupal/config/sync/core.entity_view_display.node.blog_article.teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.blog_article.teaser.yml
@@ -6,14 +6,16 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.blog_article.body
     - field.field.node.blog_article.field_images
+    - field.field.node.blog_article.field_images_legacy
     - field.field.node.blog_article.field_is_featured
     - field.field.node.blog_article.field_main_image
+    - field.field.node.blog_article.field_main_image_legacy
     - field.field.node.blog_article.field_related_content
     - field.field.node.blog_article.og_audience
     - image.style.medium
     - node.type.blog_article
   module:
-    - media
+    - svg_image
     - text
     - user
 id: node.blog_article.teaser
@@ -39,14 +41,18 @@ content:
       format_custom_true: ''
       format_custom_false: ''
     third_party_settings: {  }
-  field_main_image:
-    type: media_thumbnail
+  field_main_image_legacy:
+    type: image
     weight: 1
     region: content
     label: hidden
     settings:
       image_style: medium
       image_link: ''
+      svg_render_as_image: true
+      svg_attributes:
+        width: null
+        height: null
     third_party_settings: {  }
   links:
     weight: 0
@@ -65,6 +71,8 @@ content:
     third_party_settings: {  }
 hidden:
   field_images: true
+  field_images_legacy: true
+  field_main_image: true
   field_related_content: true
   langcode: true
   og_audience: true

--- a/src/drupal/config/sync/core.entity_view_display.node.blog_article.webbuilder_featured_teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.blog_article.webbuilder_featured_teaser.yml
@@ -6,12 +6,15 @@ dependencies:
     - core.entity_view_mode.node.webbuilder_featured_teaser
     - field.field.node.blog_article.body
     - field.field.node.blog_article.field_images
+    - field.field.node.blog_article.field_images_legacy
     - field.field.node.blog_article.field_is_featured
     - field.field.node.blog_article.field_main_image
+    - field.field.node.blog_article.field_main_image_legacy
     - field.field.node.blog_article.field_related_content
     - field.field.node.blog_article.og_audience
     - node.type.blog_article
   module:
+    - svg_image
     - text
     - user
 id: node.blog_article.webbuilder_featured_teaser
@@ -37,15 +40,19 @@ content:
       format_custom_true: ''
       format_custom_false: ''
     third_party_settings: {  }
-  field_main_image:
+  field_main_image_legacy:
+    type: image
     weight: 0
+    region: content
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
-    type: entity_reference_entity_view
-    region: content
   published_at:
     type: timestamp
     weight: 1
@@ -58,6 +65,8 @@ content:
     third_party_settings: {  }
 hidden:
   field_images: true
+  field_images_legacy: true
+  field_main_image: true
   field_related_content: true
   langcode: true
   links: true

--- a/src/drupal/config/sync/core.entity_view_display.node.blog_article.webbuilder_teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.blog_article.webbuilder_teaser.yml
@@ -6,12 +6,15 @@ dependencies:
     - core.entity_view_mode.node.webbuilder_teaser
     - field.field.node.blog_article.body
     - field.field.node.blog_article.field_images
+    - field.field.node.blog_article.field_images_legacy
     - field.field.node.blog_article.field_is_featured
     - field.field.node.blog_article.field_main_image
+    - field.field.node.blog_article.field_main_image_legacy
     - field.field.node.blog_article.field_related_content
     - field.field.node.blog_article.og_audience
     - node.type.blog_article
   module:
+    - svg_image
     - text
     - user
 id: node.blog_article.webbuilder_teaser
@@ -37,15 +40,19 @@ content:
       format_custom_true: ''
       format_custom_false: ''
     third_party_settings: {  }
-  field_main_image:
+  field_main_image_legacy:
+    type: image
     weight: 0
+    region: content
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
-    type: entity_reference_entity_view
-    region: content
   published_at:
     type: timestamp
     weight: 1
@@ -58,6 +65,8 @@ content:
     third_party_settings: {  }
 hidden:
   field_images: true
+  field_images_legacy: true
+  field_main_image: true
   field_related_content: true
   langcode: true
   links: true

--- a/src/drupal/config/sync/core.entity_view_display.node.blog_article.webbuilder_teaser_card.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.blog_article.webbuilder_teaser_card.yml
@@ -6,12 +6,15 @@ dependencies:
     - core.entity_view_mode.node.webbuilder_teaser_card
     - field.field.node.blog_article.body
     - field.field.node.blog_article.field_images
+    - field.field.node.blog_article.field_images_legacy
     - field.field.node.blog_article.field_is_featured
     - field.field.node.blog_article.field_main_image
+    - field.field.node.blog_article.field_main_image_legacy
     - field.field.node.blog_article.field_related_content
     - field.field.node.blog_article.og_audience
     - node.type.blog_article
   module:
+    - svg_image
     - text
     - user
 id: node.blog_article.webbuilder_teaser_card
@@ -37,15 +40,19 @@ content:
       format_custom_true: ''
       format_custom_false: ''
     third_party_settings: {  }
-  field_main_image:
+  field_main_image_legacy:
+    type: image
     weight: 0
+    region: content
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
-    type: entity_reference_entity_view
-    region: content
   published_at:
     type: timestamp
     weight: 1
@@ -58,6 +65,8 @@ content:
     third_party_settings: {  }
 hidden:
   field_images: true
+  field_images_legacy: true
+  field_main_image: true
   field_related_content: true
   langcode: true
   links: true

--- a/src/drupal/config/sync/core.entity_view_display.node.partner.backend_teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.partner.backend_teaser.yml
@@ -7,14 +7,15 @@ dependencies:
     - field.field.node.partner.field_akteur
     - field.field.node.partner.field_description
     - field.field.node.partner.field_main_image
+    - field.field.node.partner.field_main_image_legacy
     - field.field.node.partner.field_partner_type
     - field.field.node.partner.field_website
     - field.field.node.partner.og_audience
     - image.style.medium
     - node.type.partner
   module:
-    - media
     - options
+    - svg_image
     - text
     - user
 id: node.partner.backend_teaser
@@ -37,15 +38,19 @@ content:
     third_party_settings: {  }
     type: text_trimmed
     region: content
-  field_main_image:
+  field_main_image_legacy:
+    type: image
     weight: 1
+    region: content
     label: hidden
     settings:
       image_style: medium
       image_link: ''
+      svg_render_as_image: true
+      svg_attributes:
+        width: null
+        height: null
     third_party_settings: {  }
-    type: media_thumbnail
-    region: content
   field_partner_type:
     type: list_key
     weight: 0
@@ -62,6 +67,7 @@ content:
     type: string
     region: content
 hidden:
+  field_main_image: true
   langcode: true
   links: true
   og_audience: true

--- a/src/drupal/config/sync/core.entity_view_display.node.partner.default.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.partner.default.yml
@@ -6,14 +6,14 @@ dependencies:
     - field.field.node.partner.field_akteur
     - field.field.node.partner.field_description
     - field.field.node.partner.field_main_image
+    - field.field.node.partner.field_main_image_legacy
     - field.field.node.partner.field_partner_type
     - field.field.node.partner.field_website
     - field.field.node.partner.og_audience
-    - image.style.medium
     - node.type.partner
   module:
-    - media
     - options
+    - svg_image
     - text
     - user
 id: node.partner.default
@@ -36,14 +36,18 @@ content:
     third_party_settings: {  }
     type: text_default
     region: content
-  field_main_image:
+  field_main_image_legacy:
     weight: 1
     label: hidden
     settings:
-      image_style: medium
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
       image_link: ''
     third_party_settings: {  }
-    type: media_thumbnail
+    type: image
     region: content
   field_partner_type:
     weight: 5
@@ -66,6 +70,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_main_image: true
   langcode: true
   og_audience: true
   published_at: true

--- a/src/drupal/config/sync/core.entity_view_display.node.partner.teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.partner.teaser.yml
@@ -7,12 +7,14 @@ dependencies:
     - field.field.node.partner.field_akteur
     - field.field.node.partner.field_description
     - field.field.node.partner.field_main_image
+    - field.field.node.partner.field_main_image_legacy
     - field.field.node.partner.field_partner_type
     - field.field.node.partner.field_website
     - field.field.node.partner.og_audience
     - node.type.partner
   module:
     - options
+    - svg_image
     - text
     - user
 id: node.partner.teaser
@@ -35,14 +37,18 @@ content:
     settings:
       trim_length: 600
     third_party_settings: {  }
-  field_main_image:
-    type: entity_reference_entity_view
+  field_main_image_legacy:
+    type: image
     weight: 1
     region: content
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
   field_partner_type:
     type: list_key
@@ -52,6 +58,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_main_image: true
   field_website: true
   langcode: true
   links: true

--- a/src/drupal/config/sync/core.entity_view_display.node.partner.webbuilder_teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.partner.webbuilder_teaser.yml
@@ -7,12 +7,14 @@ dependencies:
     - field.field.node.partner.field_akteur
     - field.field.node.partner.field_description
     - field.field.node.partner.field_main_image
+    - field.field.node.partner.field_main_image_legacy
     - field.field.node.partner.field_partner_type
     - field.field.node.partner.field_website
     - field.field.node.partner.og_audience
     - node.type.partner
   module:
     - options
+    - svg_image
     - text
     - user
 id: node.partner.webbuilder_teaser
@@ -35,15 +37,19 @@ content:
     third_party_settings: {  }
     type: text_trimmed
     region: content
-  field_main_image:
+  field_main_image_legacy:
+    type: image
     weight: 0
+    region: content
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
-    type: entity_reference_entity_view
-    region: content
   field_partner_type:
     type: list_key
     weight: 4
@@ -60,6 +66,7 @@ content:
       link_to_entity: false
     third_party_settings: {  }
 hidden:
+  field_main_image: true
   langcode: true
   links: true
   og_audience: true

--- a/src/drupal/config/sync/core.entity_view_display.node.project.backend_teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.project.backend_teaser.yml
@@ -6,13 +6,16 @@ dependencies:
     - core.entity_view_mode.node.backend_teaser
     - field.field.node.project.body
     - field.field.node.project.field_images
+    - field.field.node.project.field_images_legacy
     - field.field.node.project.field_is_featured
     - field.field.node.project.field_legal_terms_accepted
     - field.field.node.project.field_main_image
+    - field.field.node.project.field_main_image_legacy
     - field.field.node.project.field_related_content
     - field.field.node.project.og_audience
     - node.type.project
   module:
+    - svg_image
     - text
     - user
 id: node.project.backend_teaser
@@ -38,15 +41,19 @@ content:
       format_custom_true: ''
       format_custom_false: ''
     third_party_settings: {  }
-  field_main_image:
-    type: entity_reference_entity_view
+  field_main_image_legacy:
+    type: image
     weight: 0
+    region: content
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
-    region: content
   published_at:
     type: timestamp
     weight: 2
@@ -59,7 +66,9 @@ content:
     third_party_settings: {  }
 hidden:
   field_images: true
+  field_images_legacy: true
   field_legal_terms_accepted: true
+  field_main_image: true
   field_related_content: true
   langcode: true
   links: true

--- a/src/drupal/config/sync/core.entity_view_display.node.project.default.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.project.default.yml
@@ -5,13 +5,16 @@ dependencies:
   config:
     - field.field.node.project.body
     - field.field.node.project.field_images
+    - field.field.node.project.field_images_legacy
     - field.field.node.project.field_is_featured
     - field.field.node.project.field_legal_terms_accepted
     - field.field.node.project.field_main_image
+    - field.field.node.project.field_main_image_legacy
     - field.field.node.project.field_related_content
     - field.field.node.project.og_audience
     - node.type.project
   module:
+    - svg_image
     - text
     - user
 id: node.project.default
@@ -26,23 +29,31 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-  field_images:
+  field_images_legacy:
     weight: 4
     label: hidden
     settings:
-      link: true
-      view_mode: default
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
-    type: entity_reference_entity_view
+    type: image
     region: content
-  field_main_image:
-    type: entity_reference_entity_view
+  field_main_image_legacy:
     weight: 1
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
+    type: image
     region: content
   field_related_content:
     weight: 5
@@ -67,7 +78,9 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  field_images: true
   field_is_featured: true
   field_legal_terms_accepted: true
+  field_main_image: true
   langcode: true
   published_at: true

--- a/src/drupal/config/sync/core.entity_view_display.node.project.in_webbuilder.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.project.in_webbuilder.yml
@@ -6,13 +6,16 @@ dependencies:
     - core.entity_view_mode.node.in_webbuilder
     - field.field.node.project.body
     - field.field.node.project.field_images
+    - field.field.node.project.field_images_legacy
     - field.field.node.project.field_is_featured
     - field.field.node.project.field_legal_terms_accepted
     - field.field.node.project.field_main_image
+    - field.field.node.project.field_main_image_legacy
     - field.field.node.project.field_related_content
     - field.field.node.project.og_audience
     - node.type.project
   module:
+    - svg_image
     - text
     - user
 id: node.project.in_webbuilder
@@ -27,15 +30,19 @@ content:
     settings: {  }
     third_party_settings: {  }
     region: content
-  field_images:
+  field_images_legacy:
+    type: image
     weight: 4
+    region: content
     label: hidden
     settings:
-      link: true
-      view_mode: default
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
-    type: entity_reference_entity_view
-    region: content
   field_is_featured:
     type: boolean
     weight: 5
@@ -46,15 +53,19 @@ content:
       format_custom_true: ''
       format_custom_false: ''
     third_party_settings: {  }
-  field_main_image:
-    type: entity_reference_entity_view
+  field_main_image_legacy:
+    type: image
     weight: 1
+    region: content
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
-    region: content
   field_related_content:
     type: entity_reference_entity_view
     weight: 6
@@ -78,6 +89,8 @@ content:
     third_party_settings: {  }
     region: content
 hidden:
+  field_images: true
   field_legal_terms_accepted: true
+  field_main_image: true
   langcode: true
   published_at: true

--- a/src/drupal/config/sync/core.entity_view_display.node.project.teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.project.teaser.yml
@@ -6,13 +6,17 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.project.body
     - field.field.node.project.field_images
+    - field.field.node.project.field_images_legacy
     - field.field.node.project.field_is_featured
     - field.field.node.project.field_legal_terms_accepted
     - field.field.node.project.field_main_image
+    - field.field.node.project.field_main_image_legacy
     - field.field.node.project.field_related_content
     - field.field.node.project.og_audience
+    - image.style.medium
     - node.type.project
   module:
+    - svg_image
     - text
     - user
 id: node.project.teaser
@@ -28,19 +32,25 @@ content:
     settings:
       trim_length: 600
     third_party_settings: {  }
-  field_main_image:
-    type: entity_reference_entity_view
+  field_main_image_legacy:
+    type: image
     weight: 0
     region: content
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      image_style: medium
+      image_link: ''
+      svg_render_as_image: true
+      svg_attributes:
+        width: null
+        height: null
     third_party_settings: {  }
 hidden:
   field_images: true
+  field_images_legacy: true
   field_is_featured: true
   field_legal_terms_accepted: true
+  field_main_image: true
   field_related_content: true
   langcode: true
   links: true

--- a/src/drupal/config/sync/core.entity_view_display.node.project.webbuilder_featured_teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.project.webbuilder_featured_teaser.yml
@@ -6,13 +6,16 @@ dependencies:
     - core.entity_view_mode.node.webbuilder_featured_teaser
     - field.field.node.project.body
     - field.field.node.project.field_images
+    - field.field.node.project.field_images_legacy
     - field.field.node.project.field_is_featured
     - field.field.node.project.field_legal_terms_accepted
     - field.field.node.project.field_main_image
+    - field.field.node.project.field_main_image_legacy
     - field.field.node.project.field_related_content
     - field.field.node.project.og_audience
     - node.type.project
   module:
+    - svg_image
     - text
     - user
 id: node.project.webbuilder_featured_teaser
@@ -38,15 +41,19 @@ content:
       format_custom_true: ''
       format_custom_false: ''
     third_party_settings: {  }
-  field_main_image:
-    type: entity_reference_entity_view
+  field_main_image_legacy:
+    type: image
     weight: 0
+    region: content
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
-    region: content
   published_at:
     type: timestamp
     weight: 2
@@ -59,7 +66,9 @@ content:
     third_party_settings: {  }
 hidden:
   field_images: true
+  field_images_legacy: true
   field_legal_terms_accepted: true
+  field_main_image: true
   field_related_content: true
   langcode: true
   links: true

--- a/src/drupal/config/sync/core.entity_view_display.node.project.webbuilder_teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.project.webbuilder_teaser.yml
@@ -6,13 +6,16 @@ dependencies:
     - core.entity_view_mode.node.webbuilder_teaser
     - field.field.node.project.body
     - field.field.node.project.field_images
+    - field.field.node.project.field_images_legacy
     - field.field.node.project.field_is_featured
     - field.field.node.project.field_legal_terms_accepted
     - field.field.node.project.field_main_image
+    - field.field.node.project.field_main_image_legacy
     - field.field.node.project.field_related_content
     - field.field.node.project.og_audience
     - node.type.project
   module:
+    - svg_image
     - text
     - user
 id: node.project.webbuilder_teaser
@@ -38,15 +41,19 @@ content:
       format_custom_true: ''
       format_custom_false: ''
     third_party_settings: {  }
-  field_main_image:
-    type: entity_reference_entity_view
+  field_main_image_legacy:
+    type: image
     weight: 0
+    region: content
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
-    region: content
   published_at:
     type: timestamp
     weight: 2
@@ -59,7 +66,9 @@ content:
     third_party_settings: {  }
 hidden:
   field_images: true
+  field_images_legacy: true
   field_legal_terms_accepted: true
+  field_main_image: true
   field_related_content: true
   langcode: true
   links: true

--- a/src/drupal/config/sync/core.entity_view_display.node.project.webbuilder_teaser_card.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.project.webbuilder_teaser_card.yml
@@ -6,13 +6,16 @@ dependencies:
     - core.entity_view_mode.node.webbuilder_teaser_card
     - field.field.node.project.body
     - field.field.node.project.field_images
+    - field.field.node.project.field_images_legacy
     - field.field.node.project.field_is_featured
     - field.field.node.project.field_legal_terms_accepted
     - field.field.node.project.field_main_image
+    - field.field.node.project.field_main_image_legacy
     - field.field.node.project.field_related_content
     - field.field.node.project.og_audience
     - node.type.project
   module:
+    - svg_image
     - text
     - user
 id: node.project.webbuilder_teaser_card
@@ -38,15 +41,19 @@ content:
       format_custom_true: ''
       format_custom_false: ''
     third_party_settings: {  }
-  field_main_image:
-    type: entity_reference_entity_view
+  field_main_image_legacy:
+    type: image
     weight: 0
+    region: content
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
-    region: content
   published_at:
     type: timestamp
     weight: 2
@@ -59,7 +66,9 @@ content:
     third_party_settings: {  }
 hidden:
   field_images: true
+  field_images_legacy: true
   field_legal_terms_accepted: true
+  field_main_image: true
   field_related_content: true
   langcode: true
   links: true

--- a/src/drupal/config/sync/core.entity_view_display.node.sponsor.backend_teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.sponsor.backend_teaser.yml
@@ -5,27 +5,32 @@ dependencies:
   config:
     - core.entity_view_mode.node.backend_teaser
     - field.field.node.sponsor.field_logo
+    - field.field.node.sponsor.field_logo_legacy
     - field.field.node.sponsor.field_website
     - field.field.node.sponsor.og_audience
     - image.style.medium
     - node.type.sponsor
   module:
-    - media
+    - svg_image
     - user
 id: node.sponsor.backend_teaser
 targetEntityType: node
 bundle: sponsor
 mode: backend_teaser
 content:
-  field_logo:
+  field_logo_legacy:
+    type: image
     weight: 0
+    region: content
     label: hidden
     settings:
       image_style: medium
       image_link: ''
+      svg_render_as_image: true
+      svg_attributes:
+        width: null
+        height: null
     third_party_settings: {  }
-    type: media_thumbnail
-    region: content
   field_website:
     weight: 1
     label: hidden
@@ -35,6 +40,7 @@ content:
     type: string
     region: content
 hidden:
+  field_logo: true
   langcode: true
   links: true
   og_audience: true

--- a/src/drupal/config/sync/core.entity_view_display.node.sponsor.default.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.sponsor.default.yml
@@ -4,26 +4,31 @@ status: true
 dependencies:
   config:
     - field.field.node.sponsor.field_logo
+    - field.field.node.sponsor.field_logo_legacy
     - field.field.node.sponsor.field_website
     - field.field.node.sponsor.og_audience
     - image.style.medium
     - node.type.sponsor
   module:
-    - media
+    - svg_image
     - user
 id: node.sponsor.default
 targetEntityType: node
 bundle: sponsor
 mode: default
 content:
-  field_logo:
+  field_logo_legacy:
     weight: 1
     label: hidden
     settings:
       image_style: medium
       image_link: ''
+      svg_render_as_image: true
+      svg_attributes:
+        width: null
+        height: null
     third_party_settings: {  }
-    type: media_thumbnail
+    type: image
     region: content
   field_website:
     weight: 2
@@ -39,6 +44,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_logo: true
   langcode: true
   og_audience: true
   published_at: true

--- a/src/drupal/config/sync/core.entity_view_display.node.sponsor.teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.sponsor.teaser.yml
@@ -5,24 +5,30 @@ dependencies:
   config:
     - core.entity_view_mode.node.teaser
     - field.field.node.sponsor.field_logo
+    - field.field.node.sponsor.field_logo_legacy
     - field.field.node.sponsor.field_website
     - field.field.node.sponsor.og_audience
     - node.type.sponsor
   module:
+    - svg_image
     - user
 id: node.sponsor.teaser
 targetEntityType: node
 bundle: sponsor
 mode: teaser
 content:
-  field_logo:
-    type: entity_reference_entity_view
+  field_logo_legacy:
+    type: image
     weight: 0
     region: content
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
   field_website:
     type: string
@@ -33,6 +39,7 @@ content:
       link_to_entity: false
     third_party_settings: {  }
 hidden:
+  field_logo: true
   langcode: true
   links: true
   og_audience: true

--- a/src/drupal/config/sync/core.entity_view_display.node.sponsor.webbuilder_teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.sponsor.webbuilder_teaser.yml
@@ -5,25 +5,31 @@ dependencies:
   config:
     - core.entity_view_mode.node.webbuilder_teaser
     - field.field.node.sponsor.field_logo
+    - field.field.node.sponsor.field_logo_legacy
     - field.field.node.sponsor.field_website
     - field.field.node.sponsor.og_audience
     - node.type.sponsor
   module:
+    - svg_image
     - user
 id: node.sponsor.webbuilder_teaser
 targetEntityType: node
 bundle: sponsor
 mode: webbuilder_teaser
 content:
-  field_logo:
+  field_logo_legacy:
+    type: image
     weight: 0
+    region: content
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
-    type: entity_reference_entity_view
-    region: content
   field_website:
     weight: 1
     label: hidden
@@ -33,6 +39,7 @@ content:
     type: string
     region: content
 hidden:
+  field_logo: true
   langcode: true
   links: true
   og_audience: true

--- a/src/drupal/config/sync/core.entity_view_display.node.webbuilder.backend_teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.webbuilder.backend_teaser.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.webbuilder.field_is_preset
     - field.field.node.webbuilder.field_layout
     - field.field.node.webbuilder.field_logo
+    - field.field.node.webbuilder.field_logo_legacy
     - field.field.node.webbuilder.field_preview_image
     - field.field.node.webbuilder.field_projects_page
     - field.field.node.webbuilder.field_twitter_link
@@ -39,6 +40,7 @@ hidden:
   field_is_preset: true
   field_layout: true
   field_logo: true
+  field_logo_legacy: true
   field_preview_image: true
   field_projects_page: true
   field_twitter_link: true

--- a/src/drupal/config/sync/core.entity_view_display.node.webbuilder.default.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.webbuilder.default.yml
@@ -14,6 +14,7 @@ dependencies:
     - field.field.node.webbuilder.field_is_preset
     - field.field.node.webbuilder.field_layout
     - field.field.node.webbuilder.field_logo
+    - field.field.node.webbuilder.field_logo_legacy
     - field.field.node.webbuilder.field_preview_image
     - field.field.node.webbuilder.field_projects_page
     - field.field.node.webbuilder.field_twitter_link
@@ -22,8 +23,8 @@ dependencies:
   module:
     - color_field
     - link
-    - media
     - options
+    - svg_image
     - user
 id: node.webbuilder.default
 targetEntityType: node
@@ -98,14 +99,18 @@ content:
     third_party_settings: {  }
     type: list_key
     region: content
-  field_logo:
-    type: media_thumbnail
+  field_logo_legacy:
     weight: 2
     label: hidden
     settings:
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
       image_style: ''
       image_link: ''
     third_party_settings: {  }
+    type: image
     region: content
   field_projects_page:
     weight: 6
@@ -134,6 +139,7 @@ content:
 hidden:
   field_description: true
   field_is_preset: true
+  field_logo: true
   field_preview_image: true
   langcode: true
   og_audience: true

--- a/src/drupal/config/sync/core.entity_view_display.node.webbuilder.teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.webbuilder.teaser.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.webbuilder.field_is_preset
     - field.field.node.webbuilder.field_layout
     - field.field.node.webbuilder.field_logo
+    - field.field.node.webbuilder.field_logo_legacy
     - field.field.node.webbuilder.field_preview_image
     - field.field.node.webbuilder.field_projects_page
     - field.field.node.webbuilder.field_twitter_link
@@ -61,6 +62,7 @@ hidden:
   field_is_preset: true
   field_layout: true
   field_logo: true
+  field_logo_legacy: true
   field_projects_page: true
   field_twitter_link: true
   langcode: true

--- a/src/drupal/config/sync/core.entity_view_display.node.webbuilder.webbuilder_preset_teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.webbuilder.webbuilder_preset_teaser.yml
@@ -15,6 +15,7 @@ dependencies:
     - field.field.node.webbuilder.field_is_preset
     - field.field.node.webbuilder.field_layout
     - field.field.node.webbuilder.field_logo
+    - field.field.node.webbuilder.field_logo_legacy
     - field.field.node.webbuilder.field_preview_image
     - field.field.node.webbuilder.field_projects_page
     - field.field.node.webbuilder.field_twitter_link
@@ -57,6 +58,7 @@ hidden:
   field_is_preset: true
   field_layout: true
   field_logo: true
+  field_logo_legacy: true
   field_projects_page: true
   field_twitter_link: true
   langcode: true

--- a/src/drupal/config/sync/core.entity_view_display.node.webbuilder_page.backend_teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.webbuilder_page.backend_teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.backend_teaser
     - field.field.node.webbuilder_page.field_contents
     - field.field.node.webbuilder_page.field_header_image
+    - field.field.node.webbuilder_page.field_header_image_legacy
     - field.field.node.webbuilder_page.field_navigation
     - field.field.node.webbuilder_page.field_parent
     - field.field.node.webbuilder_page.field_pre_footer_body
@@ -60,6 +61,7 @@ content:
 hidden:
   field_contents: true
   field_header_image: true
+  field_header_image_legacy: true
   field_parent: true
   field_pre_footer_body: true
   field_pre_footer_button: true

--- a/src/drupal/config/sync/core.entity_view_display.node.webbuilder_page.default.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.webbuilder_page.default.yml
@@ -5,6 +5,7 @@ dependencies:
   config:
     - field.field.node.webbuilder_page.field_contents
     - field.field.node.webbuilder_page.field_header_image
+    - field.field.node.webbuilder_page.field_header_image_legacy
     - field.field.node.webbuilder_page.field_navigation
     - field.field.node.webbuilder_page.field_parent
     - field.field.node.webbuilder_page.field_pre_footer_body
@@ -20,6 +21,7 @@ dependencies:
     - entity_reference_revisions
     - link
     - options
+    - svg_image
     - text
     - user
 id: node.webbuilder_page.default
@@ -36,14 +38,18 @@ content:
       link: ''
     third_party_settings: {  }
     region: content
-  field_header_image:
-    type: entity_reference_entity_view
+  field_header_image_legacy:
     weight: 6
     label: hidden
     settings:
-      view_mode: default
-      link: false
+      svg_attributes:
+        width: null
+        height: null
+      svg_render_as_image: true
+      image_style: ''
+      image_link: ''
     third_party_settings: {  }
+    type: image
     region: content
   field_navigation:
     weight: 5
@@ -113,6 +119,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_header_image: true
   field_slug: true
   field_weight: true
   langcode: true

--- a/src/drupal/config/sync/core.entity_view_display.node.webbuilder_page.in_webbuilder.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.webbuilder_page.in_webbuilder.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.in_webbuilder
     - field.field.node.webbuilder_page.field_contents
     - field.field.node.webbuilder_page.field_header_image
+    - field.field.node.webbuilder_page.field_header_image_legacy
     - field.field.node.webbuilder_page.field_navigation
     - field.field.node.webbuilder_page.field_parent
     - field.field.node.webbuilder_page.field_pre_footer_body
@@ -100,6 +101,7 @@ content:
     settings: {  }
     third_party_settings: {  }
 hidden:
+  field_header_image_legacy: true
   field_parent: true
   field_short_description: true
   field_slug: true

--- a/src/drupal/config/sync/core.entity_view_display.node.webbuilder_page.navigation.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.webbuilder_page.navigation.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.navigation
     - field.field.node.webbuilder_page.field_contents
     - field.field.node.webbuilder_page.field_header_image
+    - field.field.node.webbuilder_page.field_header_image_legacy
     - field.field.node.webbuilder_page.field_navigation
     - field.field.node.webbuilder_page.field_parent
     - field.field.node.webbuilder_page.field_pre_footer_body
@@ -48,6 +49,7 @@ content:
 hidden:
   field_contents: true
   field_header_image: true
+  field_header_image_legacy: true
   field_navigation: true
   field_pre_footer_body: true
   field_pre_footer_button: true

--- a/src/drupal/config/sync/core.entity_view_display.node.webbuilder_page.teaser.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.webbuilder_page.teaser.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.teaser
     - field.field.node.webbuilder_page.field_contents
     - field.field.node.webbuilder_page.field_header_image
+    - field.field.node.webbuilder_page.field_header_image_legacy
     - field.field.node.webbuilder_page.field_navigation
     - field.field.node.webbuilder_page.field_parent
     - field.field.node.webbuilder_page.field_pre_footer_body
@@ -32,6 +33,7 @@ content:
 hidden:
   field_contents: true
   field_header_image: true
+  field_header_image_legacy: true
   field_navigation: true
   field_parent: true
   field_pre_footer_body: true

--- a/src/drupal/config/sync/core.entity_view_display.node.webbuilder_page.webbuilder_form.yml
+++ b/src/drupal/config/sync/core.entity_view_display.node.webbuilder_page.webbuilder_form.yml
@@ -6,6 +6,7 @@ dependencies:
     - core.entity_view_mode.node.webbuilder_form
     - field.field.node.webbuilder_page.field_contents
     - field.field.node.webbuilder_page.field_header_image
+    - field.field.node.webbuilder_page.field_header_image_legacy
     - field.field.node.webbuilder_page.field_navigation
     - field.field.node.webbuilder_page.field_parent
     - field.field.node.webbuilder_page.field_pre_footer_body
@@ -46,6 +47,7 @@ content:
 hidden:
   field_contents: true
   field_header_image: true
+  field_header_image_legacy: true
   field_navigation: true
   field_pre_footer_body: true
   field_pre_footer_button: true

--- a/src/drupal/config/sync/field.field.node.blog_article.field_images_legacy.yml
+++ b/src/drupal/config/sync/field.field.node.blog_article.field_images_legacy.yml
@@ -1,0 +1,38 @@
+uuid: e780dffe-8c8b-4741-82af-ae6afbe5b59b
+langcode: de
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_images_legacy
+    - node.type.blog_article
+  module:
+    - image
+id: node.blog_article.field_images_legacy
+field_name: field_images_legacy
+entity_type: node
+bundle: blog_article
+label: Bildergalerie
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: le
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: 5MB
+  max_resolution: 1000x800
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: true
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/src/drupal/config/sync/field.field.node.blog_article.field_main_image_legacy.yml
+++ b/src/drupal/config/sync/field.field.node.blog_article.field_main_image_legacy.yml
@@ -1,0 +1,38 @@
+uuid: 6a55a9f3-9f76-4949-97a0-1fe120ebb3ad
+langcode: de
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_main_image_legacy
+    - node.type.blog_article
+  module:
+    - image
+id: node.blog_article.field_main_image_legacy
+field_name: field_main_image_legacy
+entity_type: node
+bundle: blog_article
+label: Hauptbild
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: le
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: 5MB
+  max_resolution: ''
+  min_resolution: 1000x800
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/src/drupal/config/sync/field.field.node.partner.field_main_image_legacy.yml
+++ b/src/drupal/config/sync/field.field.node.partner.field_main_image_legacy.yml
@@ -1,0 +1,38 @@
+uuid: 33e27962-aa8e-4811-b1f4-c0fa21bc9bcb
+langcode: de
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_main_image_legacy
+    - node.type.partner
+  module:
+    - image
+id: node.partner.field_main_image_legacy
+field_name: field_main_image_legacy
+entity_type: node
+bundle: partner
+label: Bild
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: le
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: 5MB
+  max_resolution: 1000x800
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/src/drupal/config/sync/field.field.node.project.field_images_legacy.yml
+++ b/src/drupal/config/sync/field.field.node.project.field_images_legacy.yml
@@ -1,0 +1,38 @@
+uuid: 77a4cf2f-87c5-4dd7-8587-f29c4a982009
+langcode: de
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_images_legacy
+    - node.type.project
+  module:
+    - image
+id: node.project.field_images_legacy
+field_name: field_images_legacy
+entity_type: node
+bundle: project
+label: Bildergalerie
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: le
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: 5MB
+  max_resolution: 1000x800
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: true
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/src/drupal/config/sync/field.field.node.project.field_main_image_legacy.yml
+++ b/src/drupal/config/sync/field.field.node.project.field_main_image_legacy.yml
@@ -1,0 +1,38 @@
+uuid: ff7dffbb-8919-4170-aea8-eab6dcbff24b
+langcode: de
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_main_image_legacy
+    - node.type.project
+  module:
+    - image
+id: node.project.field_main_image_legacy
+field_name: field_main_image_legacy
+entity_type: node
+bundle: project
+label: Hauptbild
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: le
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: 5MB
+  max_resolution: 1000x800
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/src/drupal/config/sync/field.field.node.sponsor.field_logo_legacy.yml
+++ b/src/drupal/config/sync/field.field.node.sponsor.field_logo_legacy.yml
@@ -1,0 +1,38 @@
+uuid: 41cf237c-af1e-4f89-8dea-e4974378f0c0
+langcode: de
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_logo_legacy
+    - node.type.sponsor
+  module:
+    - image
+id: node.sponsor.field_logo_legacy
+field_name: field_logo_legacy
+entity_type: node
+bundle: sponsor
+label: Logo
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: le
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: 5MB
+  max_resolution: 1000x800
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/src/drupal/config/sync/field.field.node.webbuilder.field_logo_legacy.yml
+++ b/src/drupal/config/sync/field.field.node.webbuilder.field_logo_legacy.yml
@@ -1,0 +1,38 @@
+uuid: f13772c7-be35-46d4-a86c-69b18a25aea1
+langcode: de
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_logo_legacy
+    - node.type.webbuilder
+  module:
+    - image
+id: node.webbuilder.field_logo_legacy
+field_name: field_logo_legacy
+entity_type: node
+bundle: webbuilder
+label: Logo
+description: ''
+required: false
+translatable: true
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: le
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: 5MB
+  max_resolution: 1000x800
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/src/drupal/config/sync/field.field.node.webbuilder_page.field_header_image_legacy.yml
+++ b/src/drupal/config/sync/field.field.node.webbuilder_page.field_header_image_legacy.yml
@@ -1,0 +1,38 @@
+uuid: f706bde5-0cce-44c4-b9c7-288d1e7bc918
+langcode: de
+status: true
+dependencies:
+  config:
+    - field.storage.node.field_header_image_legacy
+    - node.type.webbuilder_page
+  module:
+    - image
+id: node.webbuilder_page.field_header_image_legacy
+field_name: field_header_image_legacy
+entity_type: node
+bundle: webbuilder_page
+label: 'Bild im Kopfbereich'
+description: ''
+required: false
+translatable: false
+default_value: {  }
+default_value_callback: ''
+settings:
+  file_directory: le
+  file_extensions: 'png gif jpg jpeg'
+  max_filesize: 5MB
+  max_resolution: 1000x800
+  min_resolution: ''
+  alt_field: true
+  alt_field_required: false
+  title_field: false
+  title_field_required: false
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  handler: 'default:file'
+  handler_settings: {  }
+field_type: image

--- a/src/drupal/config/sync/field.storage.node.field_header_image_legacy.yml
+++ b/src/drupal/config/sync/field.storage.node.field_header_image_legacy.yml
@@ -1,0 +1,30 @@
+uuid: aa01d7c5-09d4-448d-9789-bc33fad35226
+langcode: de
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+id: node.field_header_image_legacy
+field_name: field_header_image_legacy
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/src/drupal/config/sync/field.storage.node.field_images_legacy.yml
+++ b/src/drupal/config/sync/field.storage.node.field_images_legacy.yml
@@ -1,0 +1,30 @@
+uuid: 7d89b0f1-080e-48a2-848d-9120d4dd9e2b
+langcode: de
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+id: node.field_images_legacy
+field_name: field_images_legacy
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: -1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/src/drupal/config/sync/field.storage.node.field_logo_legacy.yml
+++ b/src/drupal/config/sync/field.storage.node.field_logo_legacy.yml
@@ -1,0 +1,30 @@
+uuid: 33faf157-5073-45ed-b220-971d0c3a82aa
+langcode: de
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+id: node.field_logo_legacy
+field_name: field_logo_legacy
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/src/drupal/config/sync/field.storage.node.field_main_image_legacy.yml
+++ b/src/drupal/config/sync/field.storage.node.field_main_image_legacy.yml
@@ -1,0 +1,30 @@
+uuid: 56ba2c91-bfc2-4d6b-81af-44f46ac0ca5d
+langcode: de
+status: true
+dependencies:
+  module:
+    - file
+    - image
+    - node
+id: node.field_main_image_legacy
+field_name: field_main_image_legacy
+entity_type: node
+type: image
+settings:
+  uri_scheme: public
+  default_image:
+    uuid: ''
+    alt: ''
+    title: ''
+    width: null
+    height: null
+  target_type: file
+  display_field: false
+  display_default: false
+module: image
+locked: false
+cardinality: 1
+translatable: true
+indexes: {  }
+persist_with_no_fields: false
+custom_storage: false

--- a/src/drupal/patches/gin_editform_actions.patch
+++ b/src/drupal/patches/gin_editform_actions.patch
@@ -1,0 +1,27 @@
+--- dist/js/gin_editform.orig.js	2021-10-01 14:04:41.463000000 +0200
++++ dist/js/gin_editform.js	2021-10-01 14:05:07.493500867 +0200
+@@ -1,20 +1,15 @@
+ !function($, Drupal, drupalSettings) {
+   Drupal.behaviors.ginEditForm = {
+     attach: function() {
+-      var form = document.querySelector(".region-content form"), sticky = document.querySelector(".gin-sticky").cloneNode(!0), newParent = document.querySelector(".region-sticky__items__inner");
+-      0 === newParent.querySelectorAll(".gin-sticky").length && (newParent.appendChild(sticky), 
+-      newParent.querySelectorAll('input[type="submit"]').forEach((function(el) {
+-        el.setAttribute("form", form.id), el.setAttribute("id", el.getAttribute("id") + "--gin-edit-form");
+-      })), document.querySelectorAll('.field--name-status [name="status[value]"]').forEach((function(publishedState) {
++      var form = document.querySelector(".region-content form");
++      document.querySelectorAll('.field--name-status [name="status[value]"]').forEach((function(publishedState) {
+         publishedState.addEventListener("click", (function(event) {
+           var value = event.target.checked;
+           document.querySelectorAll('.field--name-status [name="status[value]"]').forEach((function(publishedState) {
+             publishedState.checked = value;
+           }));
+         }));
+-      })), setTimeout((function() {
+-        sticky.classList.add("gin-sticky--visible");
+-      })));
++      }));
+     }
+   };
+ }(jQuery, Drupal, drupalSettings);
+\ Kein Zeilenumbruch am Dateiende.

--- a/src/drupal/patches/gin_editform_theme_actions.patch
+++ b/src/drupal/patches/gin_editform_theme_actions.patch
@@ -1,0 +1,12 @@
+--- gin.orig.theme	2021-10-01 14:09:44.644000000 +0200
++++ gin.theme	2021-10-01 14:11:26.710824269 +0200
+@@ -257,9 +257,6 @@
+       $form['gin_sidebar']['footer'] = ($form['footer']) ?? [];
+       // Copy actions over.
+       $form['gin_sidebar']['actions'] = ($form['actions']) ?? [];
+-      // Unset previous added preview & submit.
+-      unset($form['gin_sidebar']['actions']['preview']);
+-      unset($form['gin_sidebar']['actions']['submit']);
+     }
+ 
+     // Attach library.

--- a/src/drupal/web/modules/custom/le_admin/assets/css/webbuilder_form.css
+++ b/src/drupal/web/modules/custom/le_admin/assets/css/webbuilder_form.css
@@ -1,0 +1,34 @@
+#edit-field-fonts {
+  display: flex;
+  flex-wrap: wrap;
+  margin-top: 2rem;
+}
+.form-item--field-fonts {
+  display: flex;
+  justify-items: start;
+  width: 22rem;
+  padding: 0.5rem;
+  margin: 0 1rem 1rem 0 !important;
+  border: 1px solid #ccc;
+  border-radius: 3px;
+}
+.form-item--field-fonts > input {
+  left: 0 !important;
+  top: 0.5rem !important;
+  float: none !important;
+  margin-left: 0 !important;
+  transform: none !important;
+  margin-right: 1rem;
+}
+
+.webbuilder-heading-font-preview {
+  line-height: 1; 
+  font-size: 2rem; 
+  font-weight: 500;
+  margin-bottom: 0.5rem;
+}
+.webbuilder-body-font-preview {
+  line-height: 1; 
+  font-size: 1.25rem; 
+  font-weight: 500;
+}

--- a/src/drupal/web/modules/custom/le_admin/assets/js/admin.js
+++ b/src/drupal/web/modules/custom/le_admin/assets/js/admin.js
@@ -81,6 +81,15 @@
     });
 
     setTimeout(jumpToSection, 500);
+
+    // move gin actions back into sidebar, to make previewer work
+    // this has to be done after a timeout, as gin js already clones these actions
+    const ginActions = document.getElementById('edit-gin-actions');
+    const ginSidebar = document.getElementById('edit-gin-sidebar');
+
+    if (ginActions && ginSidebar) {
+      ginActions.classList.remove('gin-sticky');
+    }
   }
 
   function processPreviewableItemLists() {

--- a/src/drupal/web/modules/custom/le_admin/assets/js/webbuilder_form.js
+++ b/src/drupal/web/modules/custom/le_admin/assets/js/webbuilder_form.js
@@ -1,3 +1,17 @@
 (() => {
+  function enhanceFontsDropdown() {
+    const fontsOptions = Array.from(document.querySelectorAll('input[name="field_fonts"]'));
+    
+    fontsOptions.forEach((option) => {
+      const value = option.getAttribute('value');
+      const label = document.querySelector(`label[for="${option.getAttribute('id')}"]`);
+      const fonts = value.split('+');
+      label.innerHTML = [
+        `<div class="webbuilder-heading-font-preview" style="font-family: '${fonts[0]}';">${fonts[0]}</div>`,
+        `<div class="webbuilder-body-font-preview" style="font-family: '${fonts[1]}';">${fonts[1]}</div>`,
+      ].join('\n');
+    });
+  }
 
+  enhanceFontsDropdown();
 })();

--- a/src/drupal/web/modules/custom/le_admin/includes/le_admin_form.php
+++ b/src/drupal/web/modules/custom/le_admin/includes/le_admin_form.php
@@ -213,6 +213,26 @@ function _le_admin_akteur_form_alter(&$form, FormStateInterface $form_state, $fo
 
 function _le_admin_webbuilder_form_alter(&$form, FormStateInterface $form_state, $form_id)
 {
+  $form['#attached']['library'][] = 'le_admin/webbuilder_form';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Archivo Black';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Cormorant Garamond';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Crimson Pro';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Dm Sans';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/DM Serif Display';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Eczar';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Gentium Basic';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Jost';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Kavoon';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Libre Baskerville';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Libre Franklin';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Proza Libre';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Rubik';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Rubik';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Space Grotesk';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Space Grotesk';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Taviraj';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Trirong';
+  $form['#attached']['library'][] = 'leipzigerEckenWebbuilder/Work Sans';
   $user = \Drupal::currentUser();
   $roles = $user->getRoles();
 

--- a/src/drupal/web/themes/custom/leipzigerEcken/templates/node/node--blog-article.html.twig
+++ b/src/drupal/web/themes/custom/leipzigerEcken/templates/node/node--blog-article.html.twig
@@ -94,10 +94,11 @@
   </div>
     
   <div class="col-md-7 beschreibung clearfix">
-    {% if content.field_main_image[0] %}
+    {% set image = content.field_main_image_legacy[0] | default(content.field_main_image[0]) %}
+    {% if image %}
     {{ include('@leipzigerEcken/partials/media_image.html.twig', {
       class: 'page-header',
-      image: content.field_main_image[0],
+      image: image,
       width: 665,
       image_style: 'main_image',
     }) }}
@@ -109,10 +110,11 @@
     </div>
     {% endif %}   
     
-    {% if content.field_images[0] %}
+    {% set images = content.field_images_legacy | default(content.field_image) %}
+    {% if images[0] %}
     <div class="abstand">
       {{ include('@leipzigerEcken/partials/media_image_thumbnails.html.twig', {
-        images: content.field_images
+        images: images
       }) }}
     </div>
     {% endif %}

--- a/src/drupal/web/themes/custom/leipzigerEcken/templates/node/node--project.html.twig
+++ b/src/drupal/web/themes/custom/leipzigerEcken/templates/node/node--project.html.twig
@@ -86,10 +86,11 @@
   </div>
     
   <div class="col-md-7 beschreibung clearfix">
-    {% if content.field_main_image[0] %}
+    {% set image = content.field_main_image_legacy[0] | default(content.field_main_image[0]) %}
+    {% if image %}
     {{ include('@leipzigerEcken/partials/media_image.html.twig', {
       class: 'page-header',
-      image: content.field_main_image[0],
+      image: image,
       width: 665,
       image_style: 'main_image',
     }) }}
@@ -100,11 +101,11 @@
       {{ content.body }}
     </div>
     {% endif %}   
-    
-    {% if content.field_images[0] %}
+    {% set images = content.field_images_legacy | default(content.field_image) %}
+    {% if images[0] %}
     <div class="abstand">
       {{ include('@leipzigerEcken/partials/media_image_thumbnails.html.twig', {
-        images: content.field_images
+        images: images
       }) }}
     </div>
     {% endif %}

--- a/src/drupal/web/themes/custom/leipzigerEckenWebbuilder/templates/node/_featured-teaser.html.twig
+++ b/src/drupal/web/themes/custom/leipzigerEckenWebbuilder/templates/node/_featured-teaser.html.twig
@@ -1,5 +1,5 @@
 {% set node_type = node.getType() %}
-{% set image = content.field_main_image[0] %}
+{% set image = content.field_main_image_legacy[0] | default(content.field_main_image[0]) %}
 {% set url = webbuilder_url(webbuilder_id(), 'le_webbuilder.node.' ~ node_type, {
   node: node.id(),
   destination: get_destination(),

--- a/src/drupal/web/themes/custom/leipzigerEckenWebbuilder/templates/node/_full.html.twig
+++ b/src/drupal/web/themes/custom/leipzigerEckenWebbuilder/templates/node/_full.html.twig
@@ -10,7 +10,7 @@
   {% set logo_url = logo|file_url %}
 {% endif %}
 {% set node_type = node.getType() %}
-{% set image = content.field_main_image[0] %}
+{% set image = content.field_main_image_legacy[0] | default(content.field_main_image[0]) %}
 {% set header_image = image %}
 {% set url = webbuilder_url(webbuilder_id(), 'le_webbuilder.node.' ~ node_type, {
   node: node.id()

--- a/src/drupal/web/themes/custom/leipzigerEckenWebbuilder/templates/node/_teaser-card.html.twig
+++ b/src/drupal/web/themes/custom/leipzigerEckenWebbuilder/templates/node/_teaser-card.html.twig
@@ -1,5 +1,5 @@
 {% set node_type = node.getType() %}
-{% set image = content.field_main_image[0] %}
+{% set image = content.field_main_image_legacy[0] | default(content.field_main_image[0]) %}
 {% set url = webbuilder_url(webbuilder_id(), 'le_webbuilder.node.' ~ node_type, {
   node: node.id(),
   destination: get_destination(),

--- a/src/drupal/web/themes/custom/leipzigerEckenWebbuilder/templates/node/_teaser.html.twig
+++ b/src/drupal/web/themes/custom/leipzigerEckenWebbuilder/templates/node/_teaser.html.twig
@@ -1,5 +1,5 @@
 {% set node_type = node.getType() %}
-{% set image = content.field_main_image[0] %}
+{% set image = content.field_main_image_legacy[0] | default(content.field_main_image[0]) %}
 {% set url = webbuilder_url(webbuilder_id(), 'le_webbuilder.node.' ~ node_type, {
   node: node.id(),
   destination: get_destination(),

--- a/src/drupal/web/themes/custom/leipzigerEckenWebbuilder/templates/partials/layout/header_default.html.twig
+++ b/src/drupal/web/themes/custom/leipzigerEckenWebbuilder/templates/partials/layout/header_default.html.twig
@@ -1,4 +1,4 @@
-{% set header_image = content.field_header_image[0]|default(header_image) %}
+{% set header_image = content.field_header_image_legacy[0]|default(content.field_header_image[0])|default(header_image) %}
 {% if header_image %}
 <section class="bg-gray-50 mb-16 pt-24">
   <figure class="container mx-auto px-4 sm:px-6 lg:px-8">


### PR DESCRIPTION
- adds font preview for webbuilder edit form
- fixes broken preview button, not opening split preview
- uses legacy image fields instead of media fields, at least until og group access for media is solved